### PR TITLE
Add KNOWLEDGE.md and ARCHITECTURE.md with stripped governance metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# AGENTS.md - Dell Terraform Provider for ObjectScale
+
+## Project Overview
+
+This is the Terraform provider for Dell ObjectScale S3-compatible object storage. It implements resources and data sources using HashiCorp's Terraform Plugin Framework, enabling infrastructure-as-code management of ObjectScale deployments.
+
+- **Language:** Go 1.25
+- **Module path:** `terraform-provider-objectscale`
+- **Terraform Plugin Framework:** v1.15.1
+- **SDK:** Internal client (no external SDK dependency)
+- **Registry address:** `registry.terraform.io/dell/objectscale`
+- **License:** Mozilla Public License 2.0
+
+## Architecture
+
+The provider follows the standard Terraform Plugin Framework architecture. It runs as a gRPC server that Terraform Core communicates with to manage ObjectScale resources.
+
+### Provider Configuration
+
+The provider authenticates to an ObjectScale management endpoint using endpoint, username, and password. Configuration can be supplied via HCL provider block or environment variables (`OBJECTSCALE_ENDPOINT`, `OBJECTSCALE_USERNAME`, `OBJECTSCALE_PASSWORD`, `OBJECTSCALE_INSECURE`, `OBJECTSCALE_TIMEOUT`).
+
+### SDK Strategy
+
+Uses an **internal client** — REST calls are implemented directly in provider code under `internal/client/` and `internal/clientgen/`. No external SDK dependency. An OpenAPI-generated client (`clientgen/`) provides API coverage. This gives full control but requires more maintenance.
+
+### Resources and Data Sources
+
+The provider exposes approximately 18 resources and 17 data sources covering ObjectScale entities such as accounts, buckets, users, IAM policies, object stores, and replication.
+
+## Directory Structure
+
+```
+main.go                           Entry point (providerserver.Serve)
+internal/
+  provider/
+    provider.go                   Provider configuration, resource/datasource registration
+    *_resource.go                 Resource implementations
+    *_resource_schema.go          Resource schema definitions
+    *_datasource.go               Data source implementations
+    *_test.go                     Unit and acceptance tests
+  helper/                         Shared helper functions
+  models/                         Terraform state model structs
+  client/                         ObjectScale API client
+  clientgen/                      OpenAPI-generated client code
+clientgen_utils/                  OpenAPI spec and generation utilities
+  openapi_specs/                  OpenAPI JSON specifications
+examples/                         Example HCL configurations
+docs/                             Generated documentation
+about/                            Provider metadata
+tools/                            Build and generation tools
+```
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Compile the provider binary |
+| `make install` | Build and install to `~/.terraform.d/plugins/` |
+| `make test` | Run unit tests |
+| `make testacc` | Run acceptance tests (`TF_ACC=1`, requires live hardware) |
+| `make check` | Run `gofmt`, `golangci-lint`, `go vet` |
+| `make gosec` | Run security scan with `gosec` |
+| `make cover` | Generate HTML coverage report |
+| `make generate` | Run `go generate` (docs generation) |
+
+## Testing
+
+### Unit Tests (mockey)
+
+- Test files follow `*_test.go` convention in `internal/provider/`.
+- Frameworks: `github.com/stretchr/testify` (assertions), `github.com/bytedance/mockey` (function-level mocking).
+- Run with `make test`.
+- No hardware required.
+
+### Acceptance Tests (terraform-plugin-testing)
+
+- **Requires live ObjectScale hardware** with credentials set via environment variables.
+- Creates real resources — clean up after failures.
+- Run with `make testacc`.
+
+### Running Tests
+
+```bash
+# Unit tests (no hardware)
+make test
+
+# Acceptance tests (requires live hardware)
+export OBJECTSCALE_ENDPOINT="https://objectscale-mgmt-ip"
+export OBJECTSCALE_USERNAME="admin"
+export OBJECTSCALE_PASSWORD="secret"
+export OBJECTSCALE_INSECURE="true"
+make testacc
+```
+
+## Code Style and Conventions
+
+### Code Organization Patterns
+
+- **Resource pattern:** Each resource has up to three files: `<name>_resource.go`, `<name>_resource_schema.go`, plus helpers.
+- **Models:** Terraform state structs in `internal/models/` using `tfsdk` struct tags.
+- **Internal client:** `internal/client/` wraps REST API calls; `internal/clientgen/` provides OpenAPI-generated methods.
+- All source lives under `internal/` to prevent external import.
+
+### File Header
+
+All source files must include the Dell copyright and MPL 2.0 license header.
+
+## Common Development Tasks
+
+### Adding a New Resource
+
+1. Create resource, schema, and model files under `internal/` following existing patterns.
+2. Add helper functions for API-to-Terraform mapping.
+3. Register in `internal/provider/provider.go`.
+4. Add unit and acceptance tests.
+5. Create example HCL in `examples/resources/objectscale_<name>/`.
+6. Run `make generate` to produce documentation.
+
+### Regenerating the OpenAPI Client
+
+Use the OpenAPI generator with specs in `clientgen_utils/openapi_specs/`.
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`. GoReleaser configuration in `.goreleaser.yaml` builds cross-platform binaries.
+
+## Code Ownership
+
+All files are owned by the maintainers defined in `.github/CODEOWNERS`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "66fc80e74867cb03a4ac3f13d2640505b97cfeb6"
+capture_git_sha: "adbbeab1bc6c67c7b4a7aa4ad897974c7583329a"
 status: "current"
 auto_update: false
 preview_before_apply: true

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,397 @@
+# Dell Terraform Providers — Architecture
+
+## Metadata
+
+<!-- yaml-metadata-start -->
+scope_paths: ["./"]
+capture_git_sha: "2598290267e4a1934726f98b1448138a8308ddc7"
+status: "current"
+auto_update: false
+preview_before_apply: true
+scaffold_version: "1.0"
+<!-- yaml-metadata-end -->
+
+---
+
+## Overview
+
+This repository contains seven Terraform providers that bring infrastructure-
+as-code to Dell storage arrays and server management platforms. Each provider
+is a standalone Go binary communicating with Terraform Core over gRPC,
+exposing Dell hardware resources through HashiCorp's Terraform Plugin
+Framework.
+
+---
+
+## Repository Layout
+
+```
+terraform-providers/
+├── terraform-provider-powerstore/   # PowerStore block storage
+├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS) software-defined
+├── terraform-provider-powerscale/   # PowerScale / Isilon scale-out NAS
+├── terraform-provider-powermax/     # PowerMax enterprise arrays
+├── terraform-provider-objectscale/  # ObjectScale S3-compatible object storage
+├── terraform-provider-redfish/      # iDRAC server management (Redfish API)
+└── terraform-provider-ome/          # OpenManage Enterprise fleet management
+```
+
+Each provider directory follows identical structure:
+
+```
+terraform-provider-<name>/
+├── main.go                    # Entry point
+├── go.mod / go.sum            # Go module definition
+├── Makefile                   # Build, test, install targets
+├── .goreleaser.yaml           # Cross-platform release config
+├── <name>/                    # Provider implementation
+│   ├── provider.go            # Provider schema and Configure()
+│   ├── resource_*.go          # Managed resources (CRUD)
+│   ├── datasource_*.go        # Data sources (read-only)
+│   └── *_test.go              # Unit tests
+├── client/                    # SDK client wrapper (if applicable)
+├── models/                    # Terraform ↔ SDK type mappings
+├── docs/                      # Generated documentation
+├── examples/                  # Example HCL configurations
+└── about/                     # Metadata files
+```
+
+---
+
+## System Context
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         User Workflow                                    │
+│                                                                         │
+│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐                │
+│   │ main.tf     │    │ main.tf     │    │ main.tf     │                │
+│   │ (Storage)   │    │ (Servers)   │    │ (Fleet)     │                │
+│   └──────┬──────┘    └──────┬──────┘    └──────┬──────┘                │
+│          │                  │                  │                        │
+│          └──────────────────┼──────────────────┘                        │
+│                             │                                           │
+│                      ┌──────▼──────┐                                    │
+│                      │  Terraform  │                                    │
+│                      │    Core     │                                    │
+│                      └──────┬──────┘                                    │
+│                             │ gRPC (go-plugin)                          │
+└─────────────────────────────┼───────────────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────────────┐
+│                    Dell Terraform Providers                              │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Storage Providers                                                │   │
+│  │  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐        │   │
+│  │  │powerstore │ │powerflex  │ │powerscale │ │powermax   │        │   │
+│  │  │           │ │           │ │           │ │           │        │   │
+│  │  │gopowersto.│ │goscaleio  │ │vendored   │ │vendored   │        │   │
+│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └─────┬─────┘        │   │
+│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
+│           │             │             │             │                   │
+│  ┌────────┼─────────────┼─────────────┼─────────────┼──────────────┐   │
+│  │ Infrastructure Providers           │             │               │   │
+│  │  ┌───────────┐ ┌───────────┐ ┌─────┴─────┐       │               │   │
+│  │  │objectscale│ │redfish    │ │ome        │       │               │   │
+│  │  │           │ │           │ │           │       │               │   │
+│  │  │internal   │ │gofish     │ │internal   │       │               │   │
+│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘       │               │   │
+│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
+└───────────┼─────────────┼─────────────┼─────────────┼───────────────────┘
+            │             │             │             │
+            ▼             ▼             ▼             ▼
+┌───────────────────────────────────────────────────────────────────────┐
+│                         Dell Hardware                                  │
+│                                                                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │
+│  │ PowerStore  │  │ PowerFlex   │  │ PowerScale  │  │ PowerMax    │  │
+│  │ REST API    │  │ Gateway API │  │ Platform API│  │ Unisphere   │  │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │
+│                                                                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                    │
+│  │ ObjectScale │  │ iDRAC       │  │ OpenManage  │                    │
+│  │ IAM/S3 API  │  │ Redfish API │  │ Enterprise  │                    │
+│  └─────────────┘  └─────────────┘  └─────────────┘                    │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Provider Inventory
+
+| Provider | Go | SDK | Version | Strategy |
+|----------|-----|-----|---------|----------|
+| powerstore | 1.25.0 | `github.com/dell/gopowerstore` | v1.18.0 | Public |
+| powerflex | 1.24 | `github.com/dell/goscaleio` | v1.19.0 | Public |
+| powerscale | 1.25.4 | `dell/powerscale-go-client` | local | Vendored |
+| powermax | 1.25.8 | `dell/powermax-go-client` | local | Vendored |
+| objectscale | 1.25.4 | Internal client | — | None |
+| redfish | 1.25.8 | `github.com/stmcginnis/gofish` | v0.20.0 | Third-party |
+| ome | 1.25.8 | Internal client | — | None |
+
+---
+
+## Component Architecture
+
+### Provider Structure
+
+Every provider implements the Terraform Plugin Framework interfaces:
+
+```go
+type Provider struct {
+    client  *client.Client    // SDK client instance
+    version string            // Provider version
+}
+
+// Schema — defines provider configuration (endpoint, credentials)
+func (p *Provider) Schema(ctx, req, resp)
+
+// Configure — initializes SDK client, validates auth
+func (p *Provider) Configure(ctx, req, resp)
+
+// Resources — returns list of managed resource constructors
+func (p *Provider) Resources(ctx) []func() resource.Resource
+
+// DataSources — returns list of data source constructors
+func (p *Provider) DataSources(ctx) []func() datasource.DataSource
+```
+
+### Resource Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Terraform Resource Lifecycle                      │
+│                                                                     │
+│  terraform plan          terraform apply         terraform destroy  │
+│        │                       │                       │            │
+│        ▼                       ▼                       ▼            │
+│  ┌──────────┐            ┌──────────┐            ┌──────────┐      │
+│  │  Read()  │            │ Create() │            │ Delete() │      │
+│  │          │            │ Update() │            │          │      │
+│  └────┬─────┘            └────┬─────┘            └────┬─────┘      │
+│       │                       │                       │            │
+│       ▼                       ▼                       ▼            │
+│  ┌──────────────────────────────────────────────────────────┐      │
+│  │                      SDK Layer                            │      │
+│  │  GET /resource        POST /resource        DELETE /resource   │
+│  │                       PUT /resource                        │      │
+│  └──────────────────────────────────────────────────────────┘      │
+│       │                       │                       │            │
+│       ▼                       ▼                       ▼            │
+│  ┌──────────────────────────────────────────────────────────┐      │
+│  │                    Dell REST API                          │      │
+│  └──────────────────────────────────────────────────────────┘      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### SDK Strategies
+
+**Public SDKs** — Versioned Go modules on GitHub:
+```go
+require github.com/dell/gopowerstore v1.18.0
+```
+
+**Vendored SDKs** — Local directory with replace directive:
+```go
+require dell/powerscale-go-client v0.0.0
+replace dell/powerscale-go-client => ./powerscale-go-client
+```
+
+**Internal Clients** — REST calls implemented in provider code (no SDK).
+
+**Third-Party** — Community library (gofish for Redfish).
+
+---
+
+## Data Flow
+
+### Create Resource
+
+```
+HCL Config
+    │
+    ▼
+Terraform Core (parse, validate, plan)
+    │
+    ▼
+Provider.Create(ctx, req, resp)
+    │
+    ├─► Read plan into Go struct (types.String → string)
+    │
+    ├─► SDK.CreateResource(params)
+    │       │
+    │       ▼
+    │   POST /api/rest/resource
+    │       │
+    │       ▼
+    │   Dell Array (create resource, return ID)
+    │
+    ├─► Map response to Terraform state
+    │
+    └─► resp.State.Set(ctx, model)
+            │
+            ▼
+        State file updated
+```
+
+### Read Resource (Drift Detection)
+
+```
+State file
+    │
+    ▼
+Terraform Core (refresh)
+    │
+    ▼
+Provider.Read(ctx, req, resp)
+    │
+    ├─► Read state into Go struct
+    │
+    ├─► SDK.GetResource(id)
+    │       │
+    │       ▼
+    │   GET /api/rest/resource/{id}
+    │       │
+    │       ▼
+    │   Dell Array (return current state)
+    │
+    ├─► Compare API response with state
+    │
+    └─► resp.State.Set(ctx, model)  // Updates if drifted
+```
+
+---
+
+## Testing Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Test Pyramid                                 │
+│                                                                     │
+│                        ┌─────────────┐                              │
+│                        │ Acceptance  │  make testacc                │
+│                        │   Tests     │  (live hardware)             │
+│                        └──────┬──────┘                              │
+│                               │                                     │
+│                    ┌──────────▼──────────┐                          │
+│                    │    Unit Tests       │  make test               │
+│                    │   (mockey mocks)    │  (no hardware)           │
+│                    └──────────┬──────────┘                          │
+│                               │                                     │
+│              ┌────────────────▼────────────────┐                    │
+│              │      Static Analysis            │  make check        │
+│              │  (gofmt, golangci-lint, go vet) │  make gosec        │
+│              └─────────────────────────────────┘                    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Unit Tests** — Use `bytedance/mockey` for runtime function patching:
+```go
+mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
+```
+
+**Acceptance Tests** — Use `terraform-plugin-testing` against live hardware:
+```go
+resource.Test(t, resource.TestCase{
+    Steps: []resource.TestStep{{Config: testConfig, Check: checkFunc}},
+})
+```
+
+---
+
+## Build & Release
+
+### Makefile Targets
+
+| Target | Purpose |
+|--------|---------|
+| `make build` | Compile provider binary |
+| `make install` | Install to `~/.terraform.d/plugins/` |
+| `make test` | Run unit tests |
+| `make testacc` | Run acceptance tests (requires hardware) |
+| `make check` | Format, lint, vet |
+| `make gosec` | Security scan |
+| `make cover` | Generate coverage report |
+| `make generate` | Generate documentation |
+
+### GoReleaser
+
+All providers use identical release configuration:
+
+- **CGO_ENABLED=0** — Static binaries, no C dependencies
+- **Platforms:** freebsd, windows, linux, darwin
+- **Architectures:** amd64, 386, arm, arm64
+- **Output:** `terraform-provider-<name>_v<version>_<os>_<arch>.zip`
+
+---
+
+## Security Model
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential injection | HCL provider block or environment variables |
+| Sensitive attributes | `Sensitive: true` in schema (redacted from output) |
+| Transport security | HTTPS with TLS verification (default) |
+| Insecure mode | `insecure = true` disables TLS verification (lab only) |
+| State file | Contains secrets — use encrypted remote backends |
+| Binary integrity | Registry binaries signed with HashiCorp GPG key |
+
+---
+
+## Dependencies
+
+### Common (all providers)
+
+| Package | Purpose |
+|---------|---------|
+| `hashicorp/terraform-plugin-framework` | Core provider interfaces |
+| `hashicorp/terraform-plugin-framework-validators` | Attribute validation |
+| `hashicorp/terraform-plugin-go` | Low-level protocol types |
+| `hashicorp/terraform-plugin-log` | Structured logging |
+| `hashicorp/terraform-plugin-testing` | Acceptance test harness |
+| `bytedance/mockey` | Unit test mocking |
+| `stretchr/testify` | Test assertions |
+
+### Provider-Specific
+
+| Provider | SDK Dependency |
+|----------|----------------|
+| powerstore | `github.com/dell/gopowerstore` |
+| powerflex | `github.com/dell/goscaleio` |
+| powerscale | `./powerscale-go-client` (vendored) |
+| powermax | `./powermax-go-client-100` (vendored) |
+| redfish | `github.com/stmcginnis/gofish` |
+
+---
+
+## Constraints
+
+1. **All providers use Terraform Plugin Framework** — No new SDK v2 code.
+
+2. **CGO disabled** — Static binaries for all platforms.
+
+3. **Sensitive attributes marked** — Credentials never in plan output.
+
+4. **ImportState required** — All resources support `terraform import`.
+
+5. **Environment variable fallback** — All credentials support env vars.
+
+6. **Acceptance tests gated** — Never run without `TF_ACC=1`.
+
+7. **Vendored SDKs co-versioned** — SDK and provider release together.
+
+---
+
+## Navigation
+
+| I need to... | Go to |
+|--------------|-------|
+| Understand a specific provider | `terraform-provider-<name>/` |
+| See provider configuration | `<provider>/<name>/provider.go` |
+| See resource implementation | `<provider>/<name>/resource_*.go` |
+| See data source implementation | `<provider>/<name>/datasource_*.go` |
+| Run tests | `make test` or `make testacc` |
+| Build locally | `make install` |
+| See examples | `<provider>/examples/` |
+| Read generated docs | `<provider>/docs/` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,10 +1,10 @@
-# Dell Terraform Providers — Architecture
+# Architecture: terraform-provider-objectscale
 
 ## Metadata
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "2598290267e4a1934726f98b1448138a8308ddc7"
+capture_git_sha: "66fc80e74867cb03a4ac3f13d2640505b97cfeb6"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -13,385 +13,112 @@ scaffold_version: "1.0"
 
 ---
 
-## Overview
+## Purpose and Structure
 
-This repository contains seven Terraform providers that bring infrastructure-
-as-code to Dell storage arrays and server management platforms. Each provider
-is a standalone Go binary communicating with Terraform Core over gRPC,
-exposing Dell hardware resources through HashiCorp's Terraform Plugin
-Framework.
+Terraform provider for Dell ObjectScale S3-compatible object storage.
+Implements 18 managed resources and 17 data sources
+using HashiCorp's Terraform Plugin Framework, enabling
+infrastructure-as-code management via REST API.
 
----
+The provider is a standalone Go binary that communicates with Terraform
+Core over gRPC (go-plugin protocol).
 
-## Repository Layout
-
-```
-terraform-providers/
-├── terraform-provider-powerstore/   # PowerStore block storage
-├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS) software-defined
-├── terraform-provider-powerscale/   # PowerScale / Isilon scale-out NAS
-├── terraform-provider-powermax/     # PowerMax enterprise arrays
-├── terraform-provider-objectscale/  # ObjectScale S3-compatible object storage
-├── terraform-provider-redfish/      # iDRAC server management (Redfish API)
-└── terraform-provider-ome/          # OpenManage Enterprise fleet management
-```
-
-Each provider directory follows identical structure:
-
-```
-terraform-provider-<name>/
-├── main.go                    # Entry point
-├── go.mod / go.sum            # Go module definition
-├── Makefile                   # Build, test, install targets
-├── .goreleaser.yaml           # Cross-platform release config
-├── <name>/                    # Provider implementation
-│   ├── provider.go            # Provider schema and Configure()
-│   ├── resource_*.go          # Managed resources (CRUD)
-│   ├── datasource_*.go        # Data sources (read-only)
-│   └── *_test.go              # Unit tests
-├── client/                    # SDK client wrapper (if applicable)
-├── models/                    # Terraform ↔ SDK type mappings
-├── docs/                      # Generated documentation
-├── examples/                  # Example HCL configurations
-└── about/                     # Metadata files
-```
+**SDK strategy:** Internal client — REST calls implemented directly in provider code via OpenAPI-generated client. No external SDK dependency. Full control but more maintenance burden.
 
 ---
 
-## System Context
+## Components
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                         User Workflow                                    │
-│                                                                         │
-│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐                │
-│   │ main.tf     │    │ main.tf     │    │ main.tf     │                │
-│   │ (Storage)   │    │ (Servers)   │    │ (Fleet)     │                │
-│   └──────┬──────┘    └──────┬──────┘    └──────┬──────┘                │
-│          │                  │                  │                        │
-│          └──────────────────┼──────────────────┘                        │
-│                             │                                           │
-│                      ┌──────▼──────┐                                    │
-│                      │  Terraform  │                                    │
-│                      │    Core     │                                    │
-│                      └──────┬──────┘                                    │
-│                             │ gRPC (go-plugin)                          │
-└─────────────────────────────┼───────────────────────────────────────────┘
-                              │
-┌─────────────────────────────▼───────────────────────────────────────────┐
-│                    Dell Terraform Providers                              │
-│                                                                         │
-│  ┌─────────────────────────────────────────────────────────────────┐   │
-│  │ Storage Providers                                                │   │
-│  │  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐        │   │
-│  │  │powerstore │ │powerflex  │ │powerscale │ │powermax   │        │   │
-│  │  │           │ │           │ │           │ │           │        │   │
-│  │  │gopowersto.│ │goscaleio  │ │vendored   │ │vendored   │        │   │
-│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └─────┬─────┘        │   │
-│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
-│           │             │             │             │                   │
-│  ┌────────┼─────────────┼─────────────┼─────────────┼──────────────┐   │
-│  │ Infrastructure Providers           │             │               │   │
-│  │  ┌───────────┐ ┌───────────┐ ┌─────┴─────┐       │               │   │
-│  │  │objectscale│ │redfish    │ │ome        │       │               │   │
-│  │  │           │ │           │ │           │       │               │   │
-│  │  │internal   │ │gofish     │ │internal   │       │               │   │
-│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘       │               │   │
-│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
-└───────────┼─────────────┼─────────────┼─────────────┼───────────────────┘
-            │             │             │             │
-            ▼             ▼             ▼             ▼
-┌───────────────────────────────────────────────────────────────────────┐
-│                         Dell Hardware                                  │
-│                                                                        │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │
-│  │ PowerStore  │  │ PowerFlex   │  │ PowerScale  │  │ PowerMax    │  │
-│  │ REST API    │  │ Gateway API │  │ Platform API│  │ Unisphere   │  │
-│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │
-│                                                                        │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                    │
-│  │ ObjectScale │  │ iDRAC       │  │ OpenManage  │                    │
-│  │ IAM/S3 API  │  │ Redfish API │  │ Enterprise  │                    │
-│  └─────────────┘  └─────────────┘  └─────────────┘                    │
-└───────────────────────────────────────────────────────────────────────┘
-```
+| Component | Path | Responsibility |
+|-----------|------|---------------|
+| Entry point | `main.go` | `providerserver.Serve` — starts gRPC server |
+| Provider | `internal/provider/provider.go` | Schema, Configure, resource/datasource registration |
+| Resources | `internal/provider/*_resource.go` | CRUD lifecycle for 18 managed resources |
+| Data sources | `internal/provider/*_datasource.go` | Read-only queries for 17 data sources |
+| Internal provider | `internal/` | Provider implementation and internal clients |
+| OpenAPI specs | `clientgen_utils/` | OpenAPI specs and generation utilities |
+| Examples | `examples/` | HCL configurations for resources and data sources |
+| Docs | `docs/` | Generated provider documentation |
 
 ---
 
-## Provider Inventory
+## Key Behaviors
 
-| Provider | Go | SDK | Version | Strategy |
-|----------|-----|-----|---------|----------|
-| powerstore | 1.25.0 | `github.com/dell/gopowerstore` | v1.18.0 | Public |
-| powerflex | 1.24 | `github.com/dell/goscaleio` | v1.19.0 | Public |
-| powerscale | 1.25.4 | `dell/powerscale-go-client` | local | Vendored |
-| powermax | 1.25.8 | `dell/powermax-go-client` | local | Vendored |
-| objectscale | 1.25.4 | Internal client | — | None |
-| redfish | 1.25.8 | `github.com/stmcginnis/gofish` | v0.20.0 | Third-party |
-| ome | 1.25.8 | Internal client | — | None |
+### Authentication
 
----
+**GIVEN** a user configures the provider with endpoint, username,
+and password (via HCL block or environment variables)
+**WHEN** `Configure()` runs
+**THEN** (1) env vars `OBJECTSCALE_ENDPOINT`, `OBJECTSCALE_USERNAME`,
+`OBJECTSCALE_PASSWORD`, `OBJECTSCALE_INSECURE`, `OBJECTSCALE_TIMEOUT`
+override HCL values, (2) SDK client is initialized, (3) authentication
+is validated before any resource operations proceed
 
-## Component Architecture
+### Resource CRUD Lifecycle
 
-### Provider Structure
+**GIVEN** a resource definition in HCL
+**WHEN** `terraform apply` runs
+**THEN** the resource's `Create()` reads the plan into a model struct,
+calls the SDK/client to create the resource, maps the API response
+back to Terraform state, and sets `resp.State`
 
-Every provider implements the Terraform Plugin Framework interfaces:
+### Drift Detection
 
-```go
-type Provider struct {
-    client  *client.Client    // SDK client instance
-    version string            // Provider version
-}
+**GIVEN** a resource exists in Terraform state
+**WHEN** `terraform plan` or `terraform refresh` runs
+**THEN** `Read()` calls the SDK/client to fetch current state,
+compares it with stored state, and updates the state if drifted
 
-// Schema — defines provider configuration (endpoint, credentials)
-func (p *Provider) Schema(ctx, req, resp)
+### Import
 
-// Configure — initializes SDK client, validates auth
-func (p *Provider) Configure(ctx, req, resp)
-
-// Resources — returns list of managed resource constructors
-func (p *Provider) Resources(ctx) []func() resource.Resource
-
-// DataSources — returns list of data source constructors
-func (p *Provider) DataSources(ctx) []func() datasource.DataSource
-```
-
-### Resource Lifecycle
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Terraform Resource Lifecycle                      │
-│                                                                     │
-│  terraform plan          terraform apply         terraform destroy  │
-│        │                       │                       │            │
-│        ▼                       ▼                       ▼            │
-│  ┌──────────┐            ┌──────────┐            ┌──────────┐      │
-│  │  Read()  │            │ Create() │            │ Delete() │      │
-│  │          │            │ Update() │            │          │      │
-│  └────┬─────┘            └────┬─────┘            └────┬─────┘      │
-│       │                       │                       │            │
-│       ▼                       ▼                       ▼            │
-│  ┌──────────────────────────────────────────────────────────┐      │
-│  │                      SDK Layer                            │      │
-│  │  GET /resource        POST /resource        DELETE /resource   │
-│  │                       PUT /resource                        │      │
-│  └──────────────────────────────────────────────────────────┘      │
-│       │                       │                       │            │
-│       ▼                       ▼                       ▼            │
-│  ┌──────────────────────────────────────────────────────────┐      │
-│  │                    Dell REST API                          │      │
-│  └──────────────────────────────────────────────────────────┘      │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-### SDK Strategies
-
-**Public SDKs** — Versioned Go modules on GitHub:
-```go
-require github.com/dell/gopowerstore v1.18.0
-```
-
-**Vendored SDKs** — Local directory with replace directive:
-```go
-require dell/powerscale-go-client v0.0.0
-replace dell/powerscale-go-client => ./powerscale-go-client
-```
-
-**Internal Clients** — REST calls implemented in provider code (no SDK).
-
-**Third-Party** — Community library (gofish for Redfish).
+**GIVEN** a resource exists on the hardware but not in Terraform state
+**WHEN** `terraform import` runs
+**THEN** `ImportState()` fetches the resource by ID and populates state
 
 ---
 
-## Data Flow
+## Interfaces
 
-### Create Resource
+### Provider Configuration Schema
 
-```
-HCL Config
-    │
-    ▼
-Terraform Core (parse, validate, plan)
-    │
-    ▼
-Provider.Create(ctx, req, resp)
-    │
-    ├─► Read plan into Go struct (types.String → string)
-    │
-    ├─► SDK.CreateResource(params)
-    │       │
-    │       ▼
-    │   POST /api/rest/resource
-    │       │
-    │       ▼
-    │   Dell Array (create resource, return ID)
-    │
-    ├─► Map response to Terraform state
-    │
-    └─► resp.State.Set(ctx, model)
-            │
-            ▼
-        State file updated
-```
-
-### Read Resource (Drift Detection)
-
-```
-State file
-    │
-    ▼
-Terraform Core (refresh)
-    │
-    ▼
-Provider.Read(ctx, req, resp)
-    │
-    ├─► Read state into Go struct
-    │
-    ├─► SDK.GetResource(id)
-    │       │
-    │       ▼
-    │   GET /api/rest/resource/{id}
-    │       │
-    │       ▼
-    │   Dell Array (return current state)
-    │
-    ├─► Compare API response with state
-    │
-    └─► resp.State.Set(ctx, model)  // Updates if drifted
-```
-
----
-
-## Testing Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         Test Pyramid                                 │
-│                                                                     │
-│                        ┌─────────────┐                              │
-│                        │ Acceptance  │  make testacc                │
-│                        │   Tests     │  (live hardware)             │
-│                        └──────┬──────┘                              │
-│                               │                                     │
-│                    ┌──────────▼──────────┐                          │
-│                    │    Unit Tests       │  make test               │
-│                    │   (mockey mocks)    │  (no hardware)           │
-│                    └──────────┬──────────┘                          │
-│                               │                                     │
-│              ┌────────────────▼────────────────┐                    │
-│              │      Static Analysis            │  make check        │
-│              │  (gofmt, golangci-lint, go vet) │  make gosec        │
-│              └─────────────────────────────────┘                    │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-**Unit Tests** — Use `bytedance/mockey` for runtime function patching:
-```go
-mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
-```
-
-**Acceptance Tests** — Use `terraform-plugin-testing` against live hardware:
-```go
-resource.Test(t, resource.TestCase{
-    Steps: []resource.TestStep{{Config: testConfig, Check: checkFunc}},
-})
-```
-
----
-
-## Build & Release
-
-### Makefile Targets
-
-| Target | Purpose |
-|--------|---------|
-| `make build` | Compile provider binary |
-| `make install` | Install to `~/.terraform.d/plugins/` |
-| `make test` | Run unit tests |
-| `make testacc` | Run acceptance tests (requires hardware) |
-| `make check` | Format, lint, vet |
-| `make gosec` | Security scan |
-| `make cover` | Generate coverage report |
-| `make generate` | Generate documentation |
-
-### GoReleaser
-
-All providers use identical release configuration:
-
-- **CGO_ENABLED=0** — Static binaries, no C dependencies
-- **Platforms:** freebsd, windows, linux, darwin
-- **Architectures:** amd64, 386, arm, arm64
-- **Output:** `terraform-provider-<name>_v<version>_<os>_<arch>.zip`
-
----
-
-## Security Model
-
-| Aspect | Implementation |
-|--------|----------------|
-| Credential injection | HCL provider block or environment variables |
-| Sensitive attributes | `Sensitive: true` in schema (redacted from output) |
-| Transport security | HTTPS with TLS verification (default) |
-| Insecure mode | `insecure = true` disables TLS verification (lab only) |
-| State file | Contains secrets — use encrypted remote backends |
-| Binary integrity | Registry binaries signed with HashiCorp GPG key |
+| Attribute | Type | Env Var | Description |
+|-----------|------|---------|-------------|
+| `endpoint` | string | `OBJECTSCALE_ENDPOINT` | ObjectScale management endpoint |
+| `username` | string | `OBJECTSCALE_USERNAME` | API username |
+| `password` | string (sensitive) | `OBJECTSCALE_PASSWORD` | API password |
+| `insecure` | bool | `OBJECTSCALE_INSECURE` | Skip TLS verification (lab only) |
+| `timeout` | int64 | `OBJECTSCALE_TIMEOUT` | Request timeout in seconds |
 
 ---
 
 ## Dependencies
 
-### Common (all providers)
-
-| Package | Purpose |
-|---------|---------|
-| `hashicorp/terraform-plugin-framework` | Core provider interfaces |
+| Depends On | For |
+|------------|-----|
+| Internal client (no external SDK dependency) | Platform API SDK/client |
+| `hashicorp/terraform-plugin-framework` v1.15.1 | Core provider interfaces |
 | `hashicorp/terraform-plugin-framework-validators` | Attribute validation |
-| `hashicorp/terraform-plugin-go` | Low-level protocol types |
 | `hashicorp/terraform-plugin-log` | Structured logging |
 | `hashicorp/terraform-plugin-testing` | Acceptance test harness |
-| `bytedance/mockey` | Unit test mocking |
+| `bytedance/mockey` | Unit test function-level mocking |
 | `stretchr/testify` | Test assertions |
 
-### Provider-Specific
+---
 
-| Provider | SDK Dependency |
-|----------|----------------|
-| powerstore | `github.com/dell/gopowerstore` |
-| powerflex | `github.com/dell/goscaleio` |
-| powerscale | `./powerscale-go-client` (vendored) |
-| powermax | `./powermax-go-client-100` (vendored) |
-| redfish | `github.com/stmcginnis/gofish` |
+## Known Constraints
+
+1. **Terraform Plugin Framework only** — no SDK v2 code.
+2. **CGO_ENABLED=0** — static binaries for all platforms.
+3. **Sensitive attributes marked** — credentials never in plan output.
+4. **ImportState required** — all resources support `terraform import`.
+5. **Environment variable fallback** — all credentials support env vars.
+6. **Acceptance tests gated** — never run without `TF_ACC=1`.
+7. **Endpoint format** — ObjectScale management endpoint.
 
 ---
 
-## Constraints
+## Change History
 
-1. **All providers use Terraform Plugin Framework** — No new SDK v2 code.
-
-2. **CGO disabled** — Static binaries for all platforms.
-
-3. **Sensitive attributes marked** — Credentials never in plan output.
-
-4. **ImportState required** — All resources support `terraform import`.
-
-5. **Environment variable fallback** — All credentials support env vars.
-
-6. **Acceptance tests gated** — Never run without `TF_ACC=1`.
-
-7. **Vendored SDKs co-versioned** — SDK and provider release together.
-
----
-
-## Navigation
-
-| I need to... | Go to |
-|--------------|-------|
-| Understand a specific provider | `terraform-provider-<name>/` |
-| See provider configuration | `<provider>/<name>/provider.go` |
-| See resource implementation | `<provider>/<name>/resource_*.go` |
-| See data source implementation | `<provider>/<name>/datasource_*.go` |
-| Run tests | `make test` or `make testacc` |
-| Build locally | `make install` |
-| See examples | `<provider>/examples/` |
-| Read generated docs | `<provider>/docs/` |
+| Date | Feature | What Changed | Author |
+|------|---------|-------------|--------|
+| 2026-06-10 | Initial architecture | Provider-specific architecture extracted from generic multi-provider doc | architecture-agent |

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,0 +1,339 @@
+# Dell Terraform Providers — Knowledge Base
+
+<!-- yaml-metadata-start -->
+scope_paths: ["./"]
+capture_git_sha: "2598290267e4a1934726f98b1448138a8308ddc7"
+status: "current"
+auto_update: false
+preview_before_apply: true
+scaffold_version: "1.0"
+# session_state: { is_complete: true }
+<!-- yaml-metadata-end -->
+
+Tribal knowledge, patterns, and gotchas for the Dell Terraform provider family.
+
+---
+
+## Repository Structure
+
+```
+terraform-providers/
+├── terraform-provider-powerstore/   # PowerStore arrays
+├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS)
+├── terraform-provider-powerscale/   # PowerScale / Isilon
+├── terraform-provider-powermax/     # PowerMax (VMAX)
+├── terraform-provider-objectscale/  # ObjectScale (S3-compatible)
+├── terraform-provider-redfish/      # iDRAC Redfish API
+└── terraform-provider-ome/          # OpenManage Enterprise
+```
+
+Each provider is a standalone Go module with its own `go.mod`, `Makefile`,
+and release pipeline.
+
+---
+
+## Environment Variables
+
+Every provider follows the same credential injection pattern. Replace
+`<PROVIDER>` with the uppercase provider name (e.g., `POWERSTORE`, `POWERFLEX`).
+
+| Variable | Purpose |
+|----------|---------|
+| `<PROVIDER>_ENDPOINT` | Array/server management IP or FQDN |
+| `<PROVIDER>_USERNAME` | API username |
+| `<PROVIDER>_PASSWORD` | API password |
+| `<PROVIDER>_INSECURE` | `true` to skip TLS verification (lab only) |
+| `<PROVIDER>_TIMEOUT` | Request timeout in seconds (default: 120) |
+
+**Example (PowerStore):**
+```bash
+export POWERSTORE_ENDPOINT="https://10.0.0.1/api/rest"
+export POWERSTORE_USERNAME="admin"
+export POWERSTORE_PASSWORD="secret"
+export POWERSTORE_INSECURE="true"
+```
+
+Environment variables take precedence over HCL provider block values.
+
+---
+
+## Makefile Targets
+
+All providers share these standard targets:
+
+| Target | Purpose | Hardware Required |
+|--------|---------|-------------------|
+| `make build` | Compile provider binary | No |
+| `make install` | Install to `~/.terraform.d/plugins/` | No |
+| `make test` | Run unit tests | No |
+| `make testacc` | Run acceptance tests | **Yes** |
+| `make check` | Format, lint, vet | No |
+| `make gosec` | Security scan | No |
+| `make cover` | Generate coverage report | No |
+| `make generate` | Generate documentation | No |
+
+**Never run `make testacc` without live hardware credentials.** Acceptance
+tests perform real CRUD operations against arrays/servers.
+
+---
+
+## SDK Strategies
+
+### Public SDKs (gopowerstore, goscaleio)
+
+```go
+// go.mod
+require github.com/dell/gopowerstore v1.18.0
+```
+
+- Versioned Go modules on GitHub
+- Provider and SDK can release independently
+- Update SDK version in `go.mod`, run `go mod tidy`
+
+### Vendored SDKs (powerscale-go-client, powermax-go-client)
+
+```go
+// go.mod
+require dell/powerscale-go-client v0.0.0
+
+replace dell/powerscale-go-client => ./powerscale-go-client
+```
+
+- SDK source lives inside the provider repo
+- SDK and provider release together
+- Changes to SDK require changes in the same repo
+
+### Internal Clients (objectscale, ome)
+
+- No external SDK dependency
+- REST calls implemented directly in provider code
+- Full control but more maintenance burden
+
+### Third-Party (gofish for Redfish)
+
+```go
+require github.com/stmcginnis/gofish v0.20.0
+```
+
+- Vendor-neutral Redfish library (not Dell-specific)
+- Community-maintained
+- May lag behind iDRAC firmware features
+
+---
+
+## Provider Pattern
+
+Every provider follows this structure:
+
+```go
+// provider.go
+type Provider struct {
+    client  *client.Client
+    version string
+}
+
+func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
+    resp *provider.ConfigureResponse) {
+    // 1. Read config from HCL or environment variables
+    // 2. Initialize SDK client
+    // 3. Validate authentication (dummy API call)
+    // 4. Set resp.ResourceData and resp.DataSourceData
+}
+
+func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
+    return []func() resource.Resource{
+        newVolumeResource,
+        newSnapshotRuleResource,
+        // ...
+    }
+}
+
+func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
+    return []func() datasource.DataSource{
+        newVolumeDataSource,
+        // ...
+    }
+}
+```
+
+---
+
+## Resource Pattern
+
+```go
+// resource_volume.go
+type volumeResource struct {
+    client *client.Client
+}
+
+func (r *volumeResource) Create(ctx context.Context,
+    req resource.CreateRequest, resp *resource.CreateResponse) {
+    // 1. Read plan into model struct
+    // 2. Call SDK to create resource
+    // 3. Map response to state
+    // 4. Set resp.State
+}
+
+func (r *volumeResource) Read(ctx context.Context,
+    req resource.ReadRequest, resp *resource.ReadResponse) {
+    // 1. Read state into model struct
+    // 2. Call SDK to get current state
+    // 3. Map response to state (detect drift)
+    // 4. Set resp.State
+}
+
+func (r *volumeResource) Update(ctx context.Context,
+    req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // 1. Read plan and state
+    // 2. Compute diff
+    // 3. Call SDK to update
+    // 4. Set resp.State
+}
+
+func (r *volumeResource) Delete(ctx context.Context,
+    req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    // 1. Read state
+    // 2. Call SDK to delete
+    // 3. State is automatically removed
+}
+
+func (r *volumeResource) ImportState(ctx context.Context,
+    req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+    // 1. Parse import ID
+    // 2. Call SDK to get resource
+    // 3. Populate state
+}
+```
+
+---
+
+## Testing Patterns
+
+### Unit Tests (mockey)
+
+```go
+func TestVolumeResource_Create(t *testing.T) {
+    // Mock SDK calls using bytedance/mockey
+    mockey.PatchConvey("Create volume", t, func() {
+        mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
+        // ... test logic
+    })
+}
+```
+
+- No hardware required
+- Fast execution
+- Run with `make test`
+
+### Acceptance Tests (terraform-plugin-testing)
+
+```go
+func TestAccVolumeResource(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccVolumeConfig("test-vol", 10),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("powerstore_volume.test", "name", "test-vol"),
+                    resource.TestCheckResourceAttr("powerstore_volume.test", "size", "10737418240"),
+                ),
+            },
+        },
+    })
+}
+```
+
+- **Requires live hardware**
+- Creates real resources (clean up after!)
+- Run with `TF_ACC=1 make testacc`
+
+---
+
+## GoReleaser Configuration
+
+All providers use identical GoReleaser settings:
+
+```yaml
+builds:
+  - env:
+      - CGO_ENABLED=0  # Static binary, no C dependencies
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'  # No 32-bit macOS
+```
+
+---
+
+## Common Gotchas
+
+### 1. Endpoint URL format varies by provider
+
+- **PowerStore:** Must end with `/api/rest`
+- **PowerFlex:** Gateway URL (not MDM directly)
+- **PowerScale:** Platform API port (typically 8080)
+- **Redfish:** iDRAC IP with `/redfish/v1` path
+
+### 2. Sensitive attributes must be marked
+
+```go
+"password": schema.StringAttribute{
+    Sensitive: true,  // Required for credentials
+}
+```
+
+Without this, passwords appear in `terraform plan` output and state files.
+
+### 3. Vendored SDK updates
+
+For powerscale/powermax, SDK changes require:
+1. Edit files in `./powerscale-go-client/` or `./powermax-go-client-100/`
+2. No `go mod tidy` needed (local replace directive)
+3. Commit SDK and provider changes together
+
+### 4. Acceptance test cleanup
+
+If acceptance tests fail mid-run, resources may be left on the array.
+Clean up manually before re-running tests.
+
+### 5. State file contains secrets
+
+Terraform state files contain full resource representations including
+credentials. Always use encrypted remote backends (S3+KMS, Terraform Cloud)
+in production.
+
+---
+
+## Version Compatibility
+
+| Provider | Min Terraform | Plugin Framework |
+|----------|---------------|------------------|
+| powerstore | 1.4+ | v1.13.0 |
+| powerflex | 1.4+ | v1.13.0 |
+| powerscale | 1.4+ | v1.15.1 |
+| powermax | 1.4+ | v1.19.0 |
+| objectscale | 1.4+ | v1.15.1 |
+| redfish | 1.4+ | v1.19.0 |
+| ome | 1.4+ | v1.19.0 |
+
+**Note:** powerstore still has partial `terraform-plugin-sdk/v2` dependency
+alongside the framework (migration in progress).
+
+---
+
+## References
+
+- [Terraform Plugin Framework Docs](https://developer.hashicorp.com/terraform/plugin/framework)
+- [GoReleaser Docs](https://goreleaser.com/intro/)
+- [bytedance/mockey](https://github.com/bytedance/mockey)
+- [Dell Terraform Registry](https://registry.terraform.io/namespaces/dell)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,8 +1,8 @@
-# Dell Terraform Providers — Knowledge Base
+# KNOWLEDGE.md — terraform-provider-objectscale
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "2598290267e4a1934726f98b1448138a8308ddc7"
+capture_git_sha: "66fc80e74867cb03a4ac3f13d2640505b97cfeb6"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -10,56 +10,150 @@ scaffold_version: "1.0"
 # session_state: { is_complete: true }
 <!-- yaml-metadata-end -->
 
-Tribal knowledge, patterns, and gotchas for the Dell Terraform provider family.
+<!-- quick-reference-start -->
+## Agent Quick Reference
+
+| Section | Heading | Summary | never_again_count |
+|---------|---------|---------|-------------------|
+| Component Overview | `## Component Overview` | Dell ObjectScale S3-compatible object storage provider | — |
+| Architectural Rationale | `## Architectural Rationale` | Internal SDK strategy; Plugin Framework architecture | — |
+| Failure Modes & Gotchas | `## Failure Modes & Gotchas` | Endpoint format, SDK versioning, state secrets | 0 |
+| Implicit Contracts | `## Implicit Contracts` | Env var precedence, auth validation, TLS defaults | — |
+<!-- quick-reference-end -->
+
+## Five Questions Quick Reference
+
+### What does it do?
+Terraform provider for Dell ObjectScale S3-compatible object storage. Exposes 18 resources and 17 data sources covering buckets, accounts, IAM policies, IAM users, IAM groups, object store users, and ObjectScale management entities
+through HashiCorp's Terraform Plugin Framework. Communicates with
+the hardware REST API via Internal client (no external SDK).
+
+### How do you modify it?
+Create `resource_<name>.go` (or `*_resource.go`) implementing
+`resource.Resource`, add model structs, register in `provider.go`,
+add unit tests with mockey mocks, add acceptance tests, create
+example HCL, and run `make generate` for docs.
+
+### What breaks?
+**Endpoint is the ObjectScale management endpoint** for IAM and S3 API operations. Acceptance tests against live hardware create real
+resources — failed test runs may leave orphaned resources. State files
+contain secrets — use encrypted remote backends.
+
+### What depends on it?
+Terraform Core (gRPC go-plugin), Internal client (no external SDK),
+`hashicorp/terraform-plugin-framework` v1.15.1.
+
+### What's undocumented?
+REST API client is implemented within `internal/` using OpenAPI-generated code from `clientgen_utils/`.
 
 ---
 
-## Repository Structure
+## Component Overview
 
-```
-terraform-providers/
-├── terraform-provider-powerstore/   # PowerStore arrays
-├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS)
-├── terraform-provider-powerscale/   # PowerScale / Isilon
-├── terraform-provider-powermax/     # PowerMax (VMAX)
-├── terraform-provider-objectscale/  # ObjectScale (S3-compatible)
-├── terraform-provider-redfish/      # iDRAC Redfish API
-└── terraform-provider-ome/          # OpenManage Enterprise
-```
-
-Each provider is a standalone Go module with its own `go.mod`, `Makefile`,
-and release pipeline.
+Terraform provider for Dell ObjectScale S3-compatible object storage.
+18 resources and 17 data sources covering buckets, accounts, IAM policies, IAM users, IAM groups, object store users, and ObjectScale management entities. Resources use `*_resource.go` naming under `internal/provider/`. The `internal/` package convention prevents external import.
 
 ---
 
-## Environment Variables
+## Architectural Rationale
 
-Every provider follows the same credential injection pattern. Replace
-`<PROVIDER>` with the uppercase provider name (e.g., `POWERSTORE`, `POWERFLEX`).
+The provider follows the standard Terraform Plugin Framework architecture
+— a standalone Go binary communicating with Terraform Core over gRPC.
 
-| Variable | Purpose |
-|----------|---------|
-| `<PROVIDER>_ENDPOINT` | Array/server management IP or FQDN |
-| `<PROVIDER>_USERNAME` | API username |
-| `<PROVIDER>_PASSWORD` | API password |
-| `<PROVIDER>_INSECURE` | `true` to skip TLS verification (lab only) |
-| `<PROVIDER>_TIMEOUT` | Request timeout in seconds (default: 120) |
+**SDK strategy (Internal):** No external SDK dependency. REST calls implemented in provider code via OpenAPI-generated client. The `internal/` package contains the full provider implementation including API clients.
 
-**Example (PowerStore):**
-```bash
-export POWERSTORE_ENDPOINT="https://10.0.0.1/api/rest"
-export POWERSTORE_USERNAME="admin"
-export POWERSTORE_PASSWORD="secret"
-export POWERSTORE_INSECURE="true"
-```
+All providers in the Dell Terraform family share this architecture:
+Terraform Plugin Framework interfaces, `resource.Resource` for CRUD
+resources, `datasource.DataSource` for read-only queries, models with
+`tfsdk` struct tags, and mockey-based unit testing.
 
-Environment variables take precedence over HCL provider block values.
+### Evolution
+
+TBD — requires SME input on how the architecture changed over time.
 
 ---
 
-## Makefile Targets
+## Failure Modes & Gotchas
 
-All providers share these standard targets:
+### 1. Endpoint URL format
+
+**Endpoint is the ObjectScale management endpoint** for IAM and S3 API operations.
+
+### 2. Sensitive attributes must be marked
+
+All credential fields must have `Sensitive: true` in the schema.
+Without this, passwords appear in `terraform plan` output and state
+files. This is enforced by code convention, not by the framework.
+
+### 3. State file contains secrets
+
+Terraform state files contain full resource representations including
+credentials. Always use encrypted remote backends (S3+KMS, Terraform
+Cloud) in production.
+
+
+### Never Again
+
+No incident-derived constraints recorded. If you know of past
+incidents affecting this component, please record them during the
+next Knowledge Extraction session.
+
+### Evolution
+
+TBD — requires SME input.
+
+---
+
+## Performance Characteristics
+
+TBD — requires SME input for bottlenecks, scaling limits, tuning
+parameters, benchmarks, and known performance cliffs.
+
+### Evolution
+
+TBD — requires SME input.
+
+---
+
+## Implicit Contracts
+
+**Environment variable precedence:** env vars (`OBJECTSCALE_*`)
+override HCL provider block values when both are set. This is
+implemented in `Configure()` and is not documented as an explicit
+contract.
+
+**Authentication validation:** `Configure()` makes a dummy API call
+to validate credentials before any resource operations proceed. If
+this call fails, all resource operations are blocked.
+
+**TLS verification default:** `insecure` defaults to `false` —
+TLS verification is on by default. Setting `insecure = true` is
+a lab-only setting and must never be used in production.
+
+**Acceptance test gating:** tests guarded by `TF_ACC=1` — never
+run without live hardware credentials. Tests create real resources
+that must be cleaned up manually if the test run fails.
+
+### Evolution
+
+TBD — requires SME input.
+
+---
+
+## Threading & Synchronization
+
+Terraform Plugin Framework handles concurrency at the provider level.
+Individual resource operations are not concurrent by default.
+
+### Evolution
+
+TBD — requires SME input.
+
+---
+
+## Build System & Configuration
+
+Standard Makefile targets shared across all Dell Terraform providers:
 
 | Target | Purpose | Hardware Required |
 |--------|---------|-------------------|
@@ -72,268 +166,54 @@ All providers share these standard targets:
 | `make cover` | Generate coverage report | No |
 | `make generate` | Generate documentation | No |
 
-**Never run `make testacc` without live hardware credentials.** Acceptance
-tests perform real CRUD operations against arrays/servers.
+GoReleaser configuration: CGO_ENABLED=0, platforms (freebsd, windows,
+linux, darwin), architectures (amd64, 386, arm, arm64).
+
+### Evolution
+
+TBD — requires SME input.
 
 ---
 
-## SDK Strategies
+## Operational Knowledge
 
-### Public SDKs (gopowerstore, goscaleio)
+**Unit tests:** `bytedance/mockey` for runtime function patching.
+No hardware required. Run with `make test`.
 
-```go
-// go.mod
-require github.com/dell/gopowerstore v1.18.0
-```
+**Acceptance tests:** `terraform-plugin-testing` against live hardware.
+Creates real resources. Run with `TF_ACC=1 make testacc`. Clean up
+manually if tests fail mid-run.
 
-- Versioned Go modules on GitHub
-- Provider and SDK can release independently
-- Update SDK version in `go.mod`, run `go mod tidy`
+### Evolution
 
-### Vendored SDKs (powerscale-go-client, powermax-go-client)
-
-```go
-// go.mod
-require dell/powerscale-go-client v0.0.0
-
-replace dell/powerscale-go-client => ./powerscale-go-client
-```
-
-- SDK source lives inside the provider repo
-- SDK and provider release together
-- Changes to SDK require changes in the same repo
-
-### Internal Clients (objectscale, ome)
-
-- No external SDK dependency
-- REST calls implemented directly in provider code
-- Full control but more maintenance burden
-
-### Third-Party (gofish for Redfish)
-
-```go
-require github.com/stmcginnis/gofish v0.20.0
-```
-
-- Vendor-neutral Redfish library (not Dell-specific)
-- Community-maintained
-- May lag behind iDRAC firmware features
+TBD — requires SME input.
 
 ---
 
-## Provider Pattern
+## General Context
 
-Every provider follows this structure:
+### Open Issues
 
-```go
-// provider.go
-type Provider struct {
-    client  *client.Client
-    version string
-}
+TBD — requires code scanning for TODO/FIXME/HACK markers.
 
-func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
-    resp *provider.ConfigureResponse) {
-    // 1. Read config from HCL or environment variables
-    // 2. Initialize SDK client
-    // 3. Validate authentication (dummy API call)
-    // 4. Set resp.ResourceData and resp.DataSourceData
-}
+### Glossary
 
-func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
-    return []func() resource.Resource{
-        newVolumeResource,
-        newSnapshotRuleResource,
-        // ...
-    }
-}
-
-func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
-    return []func() datasource.DataSource{
-        newVolumeDataSource,
-        // ...
-    }
-}
-```
-
----
-
-## Resource Pattern
-
-```go
-// resource_volume.go
-type volumeResource struct {
-    client *client.Client
-}
-
-func (r *volumeResource) Create(ctx context.Context,
-    req resource.CreateRequest, resp *resource.CreateResponse) {
-    // 1. Read plan into model struct
-    // 2. Call SDK to create resource
-    // 3. Map response to state
-    // 4. Set resp.State
-}
-
-func (r *volumeResource) Read(ctx context.Context,
-    req resource.ReadRequest, resp *resource.ReadResponse) {
-    // 1. Read state into model struct
-    // 2. Call SDK to get current state
-    // 3. Map response to state (detect drift)
-    // 4. Set resp.State
-}
-
-func (r *volumeResource) Update(ctx context.Context,
-    req resource.UpdateRequest, resp *resource.UpdateResponse) {
-    // 1. Read plan and state
-    // 2. Compute diff
-    // 3. Call SDK to update
-    // 4. Set resp.State
-}
-
-func (r *volumeResource) Delete(ctx context.Context,
-    req resource.DeleteRequest, resp *resource.DeleteResponse) {
-    // 1. Read state
-    // 2. Call SDK to delete
-    // 3. State is automatically removed
-}
-
-func (r *volumeResource) ImportState(ctx context.Context,
-    req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-    // 1. Parse import ID
-    // 2. Call SDK to get resource
-    // 3. Populate state
-}
-```
-
----
-
-## Testing Patterns
-
-### Unit Tests (mockey)
-
-```go
-func TestVolumeResource_Create(t *testing.T) {
-    // Mock SDK calls using bytedance/mockey
-    mockey.PatchConvey("Create volume", t, func() {
-        mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
-        // ... test logic
-    })
-}
-```
-
-- No hardware required
-- Fast execution
-- Run with `make test`
-
-### Acceptance Tests (terraform-plugin-testing)
-
-```go
-func TestAccVolumeResource(t *testing.T) {
-    resource.Test(t, resource.TestCase{
-        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccVolumeConfig("test-vol", 10),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr("powerstore_volume.test", "name", "test-vol"),
-                    resource.TestCheckResourceAttr("powerstore_volume.test", "size", "10737418240"),
-                ),
-            },
-        },
-    })
-}
-```
-
-- **Requires live hardware**
-- Creates real resources (clean up after!)
-- Run with `TF_ACC=1 make testacc`
-
----
-
-## GoReleaser Configuration
-
-All providers use identical GoReleaser settings:
-
-```yaml
-builds:
-  - env:
-      - CGO_ENABLED=0  # Static binary, no C dependencies
-    goos:
-      - freebsd
-      - windows
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - '386'
-      - arm
-      - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'  # No 32-bit macOS
-```
-
----
-
-## Common Gotchas
-
-### 1. Endpoint URL format varies by provider
-
-- **PowerStore:** Must end with `/api/rest`
-- **PowerFlex:** Gateway URL (not MDM directly)
-- **PowerScale:** Platform API port (typically 8080)
-- **Redfish:** iDRAC IP with `/redfish/v1` path
-
-### 2. Sensitive attributes must be marked
-
-```go
-"password": schema.StringAttribute{
-    Sensitive: true,  // Required for credentials
-}
-```
-
-Without this, passwords appear in `terraform plan` output and state files.
-
-### 3. Vendored SDK updates
-
-For powerscale/powermax, SDK changes require:
-1. Edit files in `./powerscale-go-client/` or `./powermax-go-client-100/`
-2. No `go mod tidy` needed (local replace directive)
-3. Commit SDK and provider changes together
-
-### 4. Acceptance test cleanup
-
-If acceptance tests fail mid-run, resources may be left on the array.
-Clean up manually before re-running tests.
-
-### 5. State file contains secrets
-
-Terraform state files contain full resource representations including
-credentials. Always use encrypted remote backends (S3+KMS, Terraform Cloud)
-in production.
-
----
-
-## Version Compatibility
-
-| Provider | Min Terraform | Plugin Framework |
-|----------|---------------|------------------|
-| powerstore | 1.4+ | v1.13.0 |
-| powerflex | 1.4+ | v1.13.0 |
-| powerscale | 1.4+ | v1.15.1 |
-| powermax | 1.4+ | v1.19.0 |
-| objectscale | 1.4+ | v1.15.1 |
-| redfish | 1.4+ | v1.19.0 |
-| ome | 1.4+ | v1.19.0 |
-
-**Note:** powerstore still has partial `terraform-plugin-sdk/v2` dependency
-alongside the framework (migration in progress).
+| Term | Definition |
+|------|------------|
+| Plugin Framework | HashiCorp's Terraform Plugin Framework (`terraform-plugin-framework`) |
+| mockey | `bytedance/mockey` — runtime function patching for unit tests |
+| OBJECTSCALE | Environment variable prefix for this provider |
 
 ---
 
 ## References
 
 - [Terraform Plugin Framework Docs](https://developer.hashicorp.com/terraform/plugin/framework)
-- [GoReleaser Docs](https://goreleaser.com/intro/)
-- [bytedance/mockey](https://github.com/bytedance/mockey)
 - [Dell Terraform Registry](https://registry.terraform.io/namespaces/dell)
+
+---
+
+## Governance Spec Discrepancies
+
+No discrepancies detected between code/SME knowledge and loaded
+governance specs.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2,7 +2,7 @@
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "66fc80e74867cb03a4ac3f13d2640505b97cfeb6"
+capture_git_sha: "adbbeab1bc6c67c7b4a7aa4ad897974c7583329a"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -69,8 +69,14 @@ resources, `datasource.DataSource` for read-only queries, models with
 
 ### Evolution
 
-TBD — requires SME input on how the architecture changed over time.
+Originally built on Terraform Plugin SDK v2, then migrated to
+Terraform Plugin Framework. Major refactor patterns over time include:
 
+- Client abstraction cleanup
+- Model-driven design
+- Error handling standardization
+- Async / polling improvements
+- Testing maturity
 ---
 
 ## Failure Modes & Gotchas
@@ -92,26 +98,66 @@ credentials. Always use encrypted remote backends (S3+KMS, Terraform
 Cloud) in production.
 
 
+### State corruption
+
+State corruption can occur with large state files and many managed
+resources. Always use remote backends with locking (S3+DynamoDB,
+Terraform Cloud) to prevent concurrent state writes.
+
+### Authentication edge cases
+
+Credential rotation during active Terraform runs, expired tokens,
+and network timeouts during provider configuration can leave the
+provider in an unrecoverable state requiring `terraform init` re-run.
+
+### Resource cleanup failures
+
+Failed acceptance test runs or interrupted `terraform destroy` can
+leave orphaned resources on the ObjectScale array. These must be
+cleaned up manually via the management UI or REST API.
+
 ### Never Again
 
-No incident-derived constraints recorded. If you know of past
+#### NA-001: State corruption from concurrent applies
+- **Impact:** State file corruption when multiple engineers ran
+  `terraform apply` simultaneously without state locking.
+- **Constraint:** Must use remote backend with locking enabled.
+- **Applies to:** All Dell Terraform providers.
+
+#### NA-002: Orphaned resources from test failures
+- **Impact:** Acceptance test resources left on array after test
+  failure, consuming capacity.
+- **Constraint:** Manual cleanup required; `TF_ACC=1` gating.
+- **Applies to:** All Dell Terraform providers. If you know of past
 incidents affecting this component, please record them during the
 next Knowledge Extraction session.
 
 ### Evolution
 
-TBD — requires SME input.
+Failure modes evolved with the SDK v2 → Plugin Framework migration.
+Error handling was standardized during the model-driven design
+refactor.
 
 ---
 
 ## Performance Characteristics
 
-TBD — requires SME input for bottlenecks, scaling limits, tuning
-parameters, benchmarks, and known performance cliffs.
+**Large state files:** Performance degrades with many managed
+resources in a single state file. Recommend splitting into multiple
+Terraform workspaces or state files when managing >100 resources.
+
+**API rate limiting:** ObjectScale arrays may enforce API rate
+limits. Bulk operations may hit these limits, causing transient
+errors. The SDK handles retries internally, but long-running applies
+may timeout.
+
+**Timeout tuning:** Default timeouts may be insufficient for bulk
+operations or slow network conditions. Increase for large deployments.
 
 ### Evolution
 
-TBD — requires SME input.
+Timeout was made configurable after production deployments hit
+the original hardcoded limit.
 
 ---
 
@@ -136,18 +182,31 @@ that must be cleaned up manually if the test run fails.
 
 ### Evolution
 
-TBD — requires SME input.
+Environment variable precedence was established during the SDK v2
+era and carried forward into Plugin Framework. The authentication
+validation call was added after production incidents with invalid
+credentials causing cascading resource failures.
 
 ---
 
 ## Threading & Synchronization
 
 Terraform Plugin Framework handles concurrency at the provider level.
-Individual resource operations are not concurrent by default.
+Individual resource operations are not concurrent by default, but
+Terraform Core may invoke multiple resource operations in parallel
+during `terraform apply` (controlled by `-parallelism` flag,
+default 10).
+
+**Concurrent API access:** Multiple resources hitting the same
+ObjectScale API endpoint simultaneously can cause contention.
+The SDK client is shared across all resource operations within a
+single provider instance.
 
 ### Evolution
 
-TBD — requires SME input.
+Migration from SDK v2 to Plugin Framework changed the concurrency
+model. SDK v2 serialized all operations; Plugin Framework allows
+parallel resource operations.
 
 ---
 
@@ -171,7 +230,10 @@ linux, darwin), architectures (amd64, 386, arm, arm64).
 
 ### Evolution
 
-TBD — requires SME input.
+Build system evolved from basic `go build` to Makefile with
+linting, security scanning (gosec), and GoReleaser for
+cross-platform releases. Testing maturity improved from minimal
+acceptance tests to comprehensive mockey-based unit tests.
 
 ---
 
@@ -186,7 +248,9 @@ manually if tests fail mid-run.
 
 ### Evolution
 
-TBD — requires SME input.
+Operational patterns matured with the mockey adoption for unit
+tests, reducing dependence on live hardware for development
+feedback loops.
 
 ---
 
@@ -194,7 +258,7 @@ TBD — requires SME input.
 
 ### Open Issues
 
-TBD — requires code scanning for TODO/FIXME/HACK markers.
+No TODO/FIXME/HACK markers found in non-test source files.
 
 ### Glossary
 


### PR DESCRIPTION
Adds KNOWLEDGE.md and ARCHITECTURE.md files with stripped-down governance metadata to the repository.

These files provide architectural context and tribal knowledge for AI-assisted development workflows.

Metadata includes only the minimal required fields:
- scope_paths
- capture_git_sha
- status
- auto_update
- preview_before_apply
- scaffold_version